### PR TITLE
Misc. Cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,9 @@ __pycache__/
 # tools/**
 # !tools/packages.config
 
+# gcc build artifacts
+*.o
+.depend
+
+# Unix Project-specific build artifacts:
+/jcp/jcp

--- a/jcp/jcp.c
+++ b/jcp/jcp.c
@@ -1526,8 +1526,12 @@ void HandleConsole() {
 						// get input from the user
 						char buf[4064];
 						printf("> ");
-						fgets(buf, 4064, stdin);
-						buf[4063]='\0';
+						if (!fgets(buf, 4064, stdin)) {
+							printf("Failed to read from stdin, code %d\n", errno);
+							buf[0]='\0';
+						} else {
+							buf[4063]='\0';
+						}
 
 						// strip EOL
 						i=(int)strlen(buf)-1;

--- a/jcp/jcp_handler.c
+++ b/jcp/jcp_handler.c
@@ -117,7 +117,10 @@ void serve_request(char *request, char *reply) {
   case SKUNK_READ_STDIN: {
     LOG("Skunk Read stdin Request\n");
     fprintf(stdout,">");
-    fgets(reply+MSGHDRSZ,MSGLENMAX,stdin);
+    if (!fgets(reply+MSGHDRSZ,MSGLENMAX,stdin)) {
+      LOG("Skunk Read stdin Request failed\n");
+      reply[MSGHDRSZ] = '\0';
+    }
     int len = 1+strlen(reply+MSGHDRSZ); // count the \0
     writeInt16(reply, len);
     break;


### PR DESCRIPTION
Just some minor cleanups that hopefully aren't controversial:

* Update the .gitignore to include *.o (gcc object files) and the jcp binary produced by the Makefile so I can keep a built jcp in my source tree, which lives inside a git submodule of my jaguar SDK without the whole jcp project showing up as out of date when I run git status in the parent project.
* Fix the last remaining warnings on my machine when building with Linux/gcc+glibc

