### PR TITLE
Extend skunkFILEREAD return value to fill register

### DIFF
--- a/jcp/skunk.s
+++ b/jcp/skunk.s
@@ -8,6 +8,7 @@
 ; Rev: 15 Feb 2009 - Make console close wait for PC acknowledgement
 ;					 Added bank switch helpers and 6MB mode handling
 ; Rev: 30 Jul 2009 - Fixed timeout loops from dbra to regular count so they aren't limited to 16-bits!
+; Rev: 21 Sep 2020 - Fixed skunkFILEREAD return value to fill entire d0 long word.
 ; 
 ; This file is licensed freely and may be used for any purpose, commercial or
 ; otherwise, without notice or compensation.
@@ -446,12 +447,13 @@ skunkFILEREAD::
 .gotresp:		
 		; get the real value again
 		move.w	d1,(a1)				; write address
+		clr.l	d2				; Clear top word of d2
 		move.w	(a1),d2				; read data
 
 		; we have input - copy it into the user's buffer at a0
 		; The length must be less than or equal to d0, and d0
 		; should have been even, so we won't enforce the values here
-		move	d2,d0				; to return to the user
+		move.l	d2,d0				; to return to the user
 		beq		.nodata				; no data to copy?
 		
 		addq	#1,d2				; so we don't lose a byte


### PR DESCRIPTION
Ensure the top word of d0 is cleared, since the
comments/documentation don't clearly indicate
whether the skunklib code uses the full 32-bits of
the registers, or just the lower words. This
shouldn't cause any harm unless some existing code
is assuming it can preserve values in the upper
word of d0 across calls to skunkFILEREAD
(unlikely), and it will save others the trouble I
went through if they assume (as I did) the
ambiguous comments/documentation imply the upper
word of d0 is saturated by skunkFILEREAD.