### PR TITLE
Default to no removers library handler on Unix too

### DIFF
--- a/jcp/Makefile
+++ b/jcp/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 CFLAGS=-O2 -Wall
-REMOVERS?=1
+REMOVERS?=0
 ifeq ($(REMOVERS),1)
 CFLAGS+=-DREMOVERS
 endif


### PR DESCRIPTION
The Visual Studio project builds without The
Removers Library handler code by default, but the
Unix Makefile defaults to enabling the Removers
handler. Since this is the upstream jcp repo, be
consistent and disable the code by default on Unix
as well.

@sbriais may have an opinion here since this would diverge from his fork, but it seems reasonable to have at least this one bit of divergence if both repositories are going to continue to exist.